### PR TITLE
feat: export images

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,28 @@ logseq-export
         [MANDATORY] Folder where all public pages are exported.
   -graphPath string
         [MANDATORY] Path to the root of your logseq graph containing /pages and /journals directories.
+  -assetsRelativePath
+        relative path within blogFolder where the assets (images) should be stored (e.g. 'static/images/logseq'). Default is logseq-images (default "logseq-images")
+  -webAssetsPathPrefix
+    	  path that the images are going to be served on on the web (e.g. '/public/images/logseq'). Default is /logseq-images (default "/logseq-images")
   -unquotedProperties string
         comma-separated list of logseq page properties that won't be quoted in the markdown frontmatter, e.g. 'date,public,slug'
 ```
+
+#### Command example
+
+This is how I run the command on my machine:
+
+```sh
+logseq-export \
+  --graphPath /Users/tomas/workspace/private/notes \
+  --blogFolder /Users/tomas/workspace/private/blog \
+  --unquotedProperties date,slug,public,tags \
+  --assetsRelativePath static/images/logseq \
+  --webAssetsPathPrefix /images/logseq
+```
+
+This will take my logseq notes and copies them to blog, it will also copy all the images to `/Users/tomas/workspace/private/blog/static/images/logseq`, but the image links themselves are going to have `/images/logseq` prefix (`![alt](/images/logseq/image.png)`).
 
 ### Logseq page properties with a special meaning (all optional)
 

--- a/file_utils.go
+++ b/file_utils.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"io"
+	"os"
+)
+
+func readFileToString(src string) (string, error) {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return "", err
+	}
+	defer srcFile.Close()
+	bytes, err := os.ReadFile(src)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func writeStringToFile(dest string, content string) error {
+	err := os.WriteFile(dest, []byte(content), os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copy(src, dest string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	destFile, err := os.Create(dest) // creates if file doesn't exist
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, srcFile) // check first var for number of bytes copied
+	if err != nil {
+		return err
+	}
+
+	err = destFile.Sync()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 type page struct {
 	filename   string
 	attributes map[string]string
+	assets     []string
 	text       string
 }
 

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func main() {
 		}
 		_, name := filepath.Split(publicFile)
 		page := parsePage(name, srcContent)
-		result := transformPage(page)
+		result := transformPage(page, "") // TODO add the --imagePathPrefix attribute
 		dest := filepath.Join(*blogFolder, result.filename)
 		folder, _ := filepath.Split(dest)
 		err = os.MkdirAll(folder, os.ModePerm)

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 	graphPath := flag.String("graphPath", "", "[MANDATORY] Folder where all public pages are exported.")
 	blogFolder := flag.String("blogFolder", "", "[MANDATORY] Folder where this program creates a new subfolder with public logseq pages.")
 	assetsRelativePath := flag.String("assetsRelativePath", "logseq-images", "relative path within blogFolder where the assets (images) should be stored (e.g. 'static/images/logseq'). Default is `logseq-images`")
-	imagePathPrefix := flag.String("imagePathPrefix", "/logseq-images", "path that the images are going to be served on on the web (e.g. '/public/images/logseq'). Default is `/logseq-images`")
+	webAssetsPathPrefix := flag.String("webAssetsPathPrefix", "/logseq-images", "path that the images are going to be served on on the web (e.g. '/public/images/logseq'). Default is `/logseq-images`")
 	unquotedProperties := flag.String("unquotedProperties", "", "comma-separated list of logseq page properties that won't be quoted in the markdown front matter, e.g. 'date,public,slug")
 	flag.Parse()
 	if *graphPath == "" || *blogFolder == "" {
@@ -73,7 +73,7 @@ func main() {
 		}
 		_, name := filepath.Split(publicFile)
 		page := parsePage(name, srcContent)
-		result := transformPage(page, *imagePathPrefix)
+		result := transformPage(page, *webAssetsPathPrefix)
 		assetFolder := filepath.Join(*blogFolder, *assetsRelativePath)
 		err = copyAssets(publicFile, assetFolder, result.assets)
 		if err != nil {

--- a/transform.go
+++ b/transform.go
@@ -75,6 +75,7 @@ func unindentMultilineStrings(from string) string {
 	})
 }
 
+// onlyText turns text transformer into a page transformer
 func onlyText(textTransformer func(string) string) func(page) page {
 	return func(p page) page {
 		p.text = textTransformer(p.text)
@@ -90,6 +91,11 @@ func applyAll(from page, transformers ...func(page) page) page {
 	return result
 }
 
+/*
+extractAssets finds all markdown images with **relative** URL e.g. `![alt](../assets/image.png)`
+it extracts the relative URL into a `page.assets“ array
+it replaces the relative links with `imagePrefixPath“: `{imagePrefixPath}/image.png`
+*/
 func extractAssets(imagePrefixPath string) func(page) page {
 	return func(p page) page {
 		assetRegexp := regexp.MustCompile(`!\[.*?]\((\.\.?/.+?)\)`)

--- a/transform.go
+++ b/transform.go
@@ -76,6 +76,15 @@ func applyAll(from string, transformers ...func(string) string) string {
 	return result
 }
 
+func extractAssets(p page) []string {
+	links := regexp.MustCompile(`!\[.*?]\((\.\.?/.+?)\)`).FindAllStringSubmatch(p.text, -1)
+	result := make([]string, 0, len(links))
+	for _, l := range links {
+		result = append(result, l[1])
+	}
+	return result
+}
+
 func transformPage(p page) page {
 	filename := generateFileName(p.filename, p.attributes)
 	folder := filepath.Join(path.Split(p.attributes["folder"])) // the page property always uses `/` but the final delimiter is OS-dependent
@@ -90,6 +99,7 @@ func transformPage(p page) page {
 	return page{
 		filename:   filepath.Join(folder, filename),
 		attributes: p.attributes,
+		assets:     extractAssets(p),
 		text:       text,
 	}
 }

--- a/transform.go
+++ b/transform.go
@@ -117,7 +117,7 @@ func extractAssets(imagePrefixPath string) func(page) page {
 	}
 }
 
-func transformPage(p page, imagePathPrefix string) page {
+func transformPage(p page, webAssetsPathPrefix string) page {
 	return applyAll(
 		p,
 		addFileName,
@@ -126,6 +126,6 @@ func transformPage(p page, imagePathPrefix string) page {
 		onlyText(firstBulletPointsToParagraphs),
 		onlyText(secondToFirstBulletPoints),
 		onlyText(removeTabFromMultiLevelBulletPoints),
-		extractAssets(imagePathPrefix),
+		extractAssets(webAssetsPathPrefix),
 	)
 }

--- a/transform_test.go
+++ b/transform_test.go
@@ -43,7 +43,7 @@ func transformText(from string) string {
 		attributes: map[string]string{},
 		text:       from,
 	}
-	result := transformPage(testPage)
+	result := transformPage(testPage, "")
 	return result.text
 }
 
@@ -57,7 +57,7 @@ func TestTransformPage(t *testing.T) {
 			},
 			text: "",
 		}
-		result := transformPage(testPage)
+		result := transformPage(testPage, "")
 		require.Equal(t, "2022-09-24-this-is-a-slug.md", result.filename)
 	})
 
@@ -69,7 +69,7 @@ func TestTransformPage(t *testing.T) {
 			},
 			text: "",
 		}
-		result := transformPage(testPage)
+		result := transformPage(testPage, "")
 		require.Equal(t, filepath.Join("content", "posts", "name-with-space.md"), result.filename)
 	})
 
@@ -123,16 +123,16 @@ func TestTransformImages(t *testing.T) {
 			filename: "a.md",
 			text:     "- ![hello world](../assets/image.png)",
 		}
-		result := transformPage(testPage)
+		result := transformPage(testPage, "/images")
 		require.Equal(t, []string{"../assets/image.png"}, result.assets)
-		require.Equal(t, "\n![hello world](../assets/image.png)", result.text)
+		require.Equal(t, "\n![hello world](/images/image.png)", result.text)
 	})
 	t.Run("ignores absolute images", func(t *testing.T) {
 		testPage := page{
 			filename: "a.md",
 			text:     "- ![hello world](http://example.com/assets/image.png)",
 		}
-		result := transformPage(testPage)
+		result := transformPage(testPage, "/images")
 		require.Equal(t, 0, len(result.assets))
 		require.Equal(t, "\n![hello world](http://example.com/assets/image.png)", result.text)
 	})

--- a/transform_test.go
+++ b/transform_test.go
@@ -116,3 +116,24 @@ in
 one`, result)
 	})
 }
+
+func TestTransformImages(t *testing.T) {
+	t.Run("extracts relative images", func(t *testing.T) {
+		testPage := page{
+			filename: "a.md",
+			text:     "- ![hello world](../assets/image.png)",
+		}
+		result := transformPage(testPage)
+		require.Equal(t, []string{"../assets/image.png"}, result.assets)
+		require.Equal(t, "\n![hello world](../assets/image.png)", result.text)
+	})
+	t.Run("ignores absolute images", func(t *testing.T) {
+		testPage := page{
+			filename: "a.md",
+			text:     "- ![hello world](http://example.com/assets/image.png)",
+		}
+		result := transformPage(testPage)
+		require.Equal(t, 0, len(result.assets))
+		require.Equal(t, "\n![hello world](http://example.com/assets/image.png)", result.text)
+	})
+}


### PR DESCRIPTION
This MR introduces basic logic for exporting all images that are referenced in markdown images (`![alt](../assets/image.png)`)