### PR TITLE
Add flag to render parameters in list format

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ logseq-export
     	  path that the images are going to be served on on the web (e.g. '/public/images/logseq'). Default is /logseq-images (default "/logseq-images")
   -unquotedProperties string
         comma-separated list of logseq page properties that won't be quoted in the markdown frontmatter, e.g. 'date,public,slug'
+  --listProperties string
+        comma-separated list of logseq page properties that will be converted to a list in the mardown frontmatter, e.g. 'tags,series'
 ```
 
 #### Command example

--- a/main.go
+++ b/main.go
@@ -89,8 +89,8 @@ func parseOptions() exportOptions {
 		flag.Usage()
 		os.Exit(1)
 	}
-	unquotedProperties := parseUnquotedProperties(*rawUnquotedProperties)
-	listProperties := parseUnquotedProperties(*rawListProperties) // TODO reusing this - needs rename
+	unquotedProperties := parsePropertyNames(*rawUnquotedProperties)
+	listProperties := parsePropertyNames(*rawListProperties)
 	return exportOptions{
 		graphPath:           *graphPath,
 		blogFolder:          *blogFolder,
@@ -161,7 +161,7 @@ func copyAssets(appFS afero.Fs, baseFile string, assetFolder string, assets []st
 	return nil
 }
 
-func parseUnquotedProperties(param string) []string {
+func parsePropertyNames(param string) []string {
 	if param == "" {
 		return []string{}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -49,7 +49,7 @@ func TestRender(t *testing.T) {
 			},
 			text: "page text",
 		}
-		result := render(testPage, []string{})
+		result := render(testPage, []string{}, []string{})
 		require.Equal(t, `---
 first: "1"
 second: "2"
@@ -68,7 +68,7 @@ page text`, result)
 			},
 			text: "page text",
 		}
-		result := render(testPage, []string{})
+		result := render(testPage, []string{}, []string{})
 		require.Equal(t, `---
 a: "1"
 b: "1"
@@ -87,10 +87,26 @@ page text`, result)
 			},
 			text: "page text",
 		}
-		result := render(testPage, []string{"first", "second"})
+		result := render(testPage, []string{"first", "second"}, []string{})
 		require.Equal(t, `---
 first: 1
 second: 2
+---
+page text`, result)
+	})
+	t.Run("it renders formatted lists of attributes", func(t *testing.T) {
+		testPage := page{
+			filename: "",
+			attributes: map[string]string{
+				"first":  "single",
+				"second": "tag1, tag2",
+			},
+			text: "page text",
+		}
+		result := render(testPage, []string{}, []string{"first", "second"})
+		require.Equal(t, `---
+first: ["single"]
+second: ["tag1", "tag2"]
 ---
 page text`, result)
 	})


### PR DESCRIPTION
## What

Add the command line parameter of `--listProperties` that converts a property to a list.

## Why

When exporting to Logseq for use in [Hugo](https://gohugo.io), some of the front matter is expected to be in a list. For example:

```markdown
tags: ["book", "go"]
```

The current exporter will export them like they are in Logseq, either:

```
tags: "book, go"
```

or like this if you use the `--unquotedProperties tags` parameter:

```
tags: book,go
```

Hugo will not start up because it does not know how to parse those types of lists.

## How

I followed the pattern with `unquotedProperties`

## Testing

I added a test to the `main_test.go`